### PR TITLE
🐛stop Yarn_V1 getting confused in Yarn_V2 nested worktree

### DIFF
--- a/__tests__/Repkgs_Compat_test.re
+++ b/__tests__/Repkgs_Compat_test.re
@@ -191,7 +191,7 @@ describe("Compat", () => {
   });
   describe("detect", () => {
     describe("Pnpm workspace", () => {
-      let dir = "pnpm";
+      let dir = "pnpm/workspace-a";
       let cwd = Node.Path.join2(fixturesDir, dir);
       test("Pnpm", () =>
         cwd |> Pnpm.detect |> expect |> toBe(true)
@@ -207,7 +207,7 @@ describe("Compat", () => {
       );
     });
     describe("Rush workspace", () => {
-      let dir = "rush";
+      let dir = "rush/workspace-a";
       let cwd = Node.Path.join2(fixturesDir, dir);
       test("Pnpm", () =>
         cwd |> Pnpm.detect |> expect |> toBe(false)
@@ -223,7 +223,7 @@ describe("Compat", () => {
       );
     });
     describe("Yarn_V1 workspace", () => {
-      let dir = "yarn";
+      let dir = "yarn/workspace-a";
       let cwd = Node.Path.join2(fixturesDir, dir);
       test("Pnpm", () =>
         cwd |> Pnpm.detect |> expect |> toBe(false)
@@ -239,7 +239,7 @@ describe("Compat", () => {
       );
     });
     describe("Yarn_V2 workspace", () => {
-      let dir = "berry";
+      let dir = "berry/workspace-a";
       let cwd = Node.Path.join2(fixturesDir, dir);
       test("Pnpm", () =>
         cwd |> Pnpm.detect |> expect |> toBe(false)

--- a/src/Repkgs/Repkgs_Compat.re
+++ b/src/Repkgs/Repkgs_Compat.re
@@ -43,12 +43,14 @@ module Common = {
     };
   };
 
-  let rec findHighestWorktree = (path, patterns, ~closest=None, ()) => {
+  let rec findHighestWorktree = (path, patterns, ~closest=None, ~depth=3, ()) => {
     let cwd = Node.Path.resolve(path, "");
+    Js.log(cwd);
+    Js.log(depth);
     let ws = cwd->patterns;
 
     switch (cwd) {
-    | cwd when cwd == Node.Path.parse(cwd)##root =>
+    | cwd when depth === 0 || cwd == Node.Path.parse(cwd)##root =>
       switch (closest) {
       | Some(closest) => Belt.Result.Ok(closest)
       | None => Belt.Result.Error("No Workspace Found")
@@ -60,8 +62,8 @@ module Common = {
           patterns,
         );
       switch (ws) {
-      | [||] => fhw(~closest, ())
-      | _ => fhw(~closest=Some(cwd), ())
+      | [||] => fhw(~closest, ~depth=depth - 1, ())
+      | _ => fhw(~closest=Some(cwd), ~depth=3, ())
       };
     };
   };
@@ -154,7 +156,7 @@ module Yarn_V1 = {
 
   let patterns = path => [|path, manifest|]->read->parse->(m => m.workspaces);
 
-  let findRoot = path => path->Common.findClosestWorktree(patterns);
+  let findRoot = path => path->Common.findHighestWorktree(patterns, ());
 
   let packages = cwd => cwd->Common.packages(~patterns, ());
 


### PR DESCRIPTION
- When run from a Yarn_V2 nested workspace both Yarn_V2 and Yarn_V1 were set to active.
- This makes sense since a nested v2 workspace is a valid v1 workspace.
- This was fixed by adding nested support to Yarn_V1 so it will continue up the tree to make sure it isn't in a Yarn_V2 project.