### PR TITLE
🛠pass file path with Import type

### DIFF
--- a/src/components/VerifyFiles.re
+++ b/src/components/VerifyFiles.re
@@ -88,15 +88,13 @@ let make =
                  />
                  <VerifyFilesMissingImports
                    name="required files not in pack:"
-                   imports={vp.packed.imports->ImportSet.keepLocalImports}
-                   files={vp.packed.files}
-                   path={vp.pkg->Package.path}
+                   required={vp.packed.imports->ImportSet.keepLocalImports}
+                   found={vp.packed.files}
                  />
                  <VerifyFilesMissingImports
-                   name="broken imports:"
-                   imports={vp.packed.imports->ImportSet.keepBrokenImports}
-                   files={vp.packed.files}
-                   path={vp.pkg->Package.path}
+                   name="local import does not exist:"
+                   required={vp.packed.imports->ImportSet.keepBrokenImports}
+                   found={vp.packed.files}
                  />
                </Box>
              </Box>

--- a/src/components/VerifyFiles.re
+++ b/src/components/VerifyFiles.re
@@ -90,11 +90,7 @@ let make =
                    name="required files not in pack:"
                    required={vp.packed.imports->ImportSet.keepLocalImports}
                    found={vp.packed.files}
-                 />
-                 <VerifyFilesMissingImports
-                   name="local import does not exist:"
-                   required={vp.packed.imports->ImportSet.keepBrokenImports}
-                   found={vp.packed.files}
+                   path={vp.pkg->Package.path}
                  />
                </Box>
              </Box>

--- a/src/components/VerifyFilesMissingImports.re
+++ b/src/components/VerifyFilesMissingImports.re
@@ -1,7 +1,7 @@
 include Ink;
 
 [@react.component]
-let make = (~name, ~required, ~found) => {
+let make = (~name, ~required, ~found, ~path) => {
   switch (ImportSet.diff(required, found)->ImportSet.toArray) {
   | [||] => React.null
   | arr =>
@@ -11,9 +11,16 @@ let make = (~name, ~required, ~found) => {
       </Border>
       {arr
        ->Array.map(a =>
-           <Border key={a->ImportSet.Import.toString}>
+           <Border key={a->ImportSet.Import.target->Path.toString}>
              <Color red=true>
-               {("\t" ++ a->ImportSet.Import.toString)->React.string}
+               {(
+                  "\t"
+                  ++ a
+                     ->ImportSet.Import.target
+                     ->Path.relativize(~cwd=path)
+                     ->Path.toString
+                )
+                ->React.string}
              </Color>
            </Border>
          )

--- a/src/components/VerifyFilesMissingImports.re
+++ b/src/components/VerifyFilesMissingImports.re
@@ -1,8 +1,8 @@
 include Ink;
 
 [@react.component]
-let make = (~name, ~imports, ~files, ~path) => {
-  switch (ImportSet.diff(imports, files)->ImportSet.toArray) {
+let make = (~name, ~required, ~found) => {
+  switch (ImportSet.diff(required, found)->ImportSet.toArray) {
   | [||] => React.null
   | arr =>
     <Box flexDirection="column">
@@ -13,7 +13,7 @@ let make = (~name, ~imports, ~files, ~path) => {
        ->Array.map(a =>
            <Border key={a->ImportSet.Import.toString}>
              <Color red=true>
-               {("\t" ++ a->ImportSet.Import.pp(~cwd=path))->React.string}
+               {("\t" ++ a->ImportSet.Import.toString)->React.string}
              </Color>
            </Border>
          )

--- a/src/library/ImportSet.re
+++ b/src/library/ImportSet.re
@@ -1,8 +1,9 @@
 module Import = {
+  type import = string;
   type t =
-    | Local(Path.t)
-    | Unresolved(Path.t)
-    | External(string);
+    | Local(import, Path.t)
+    | Unresolved(import, Path.t)
+    | External(import);
   let v = (import, ~path) => {
     let x = import->String.get(0);
     switch (x) {
@@ -14,8 +15,8 @@ module Import = {
       ->Resolve.resolve
       ->(
           fun
-          | Ok(p) => Local(p)
-          | _ => Unresolved(filePath)
+          | Ok(p) => Local(import, p)
+          | _ => Unresolved(import, filePath)
         );
     // External could also be ../../node_modules/@thing/beep
     // so need to handle that at some point
@@ -24,10 +25,9 @@ module Import = {
   };
   let toString =
     fun
-    | Local(p)
-    | Unresolved(p) => p->Path.toString
+    | Local(s, _)
+    | Unresolved(s, _)
     | External(s) => s;
-  let pp = (x, ~cwd) => x->toString->Path.v->Path.relativize(~cwd)->Path.pp;
 };
 
 module Comparator =

--- a/src/library/ImportSet.re
+++ b/src/library/ImportSet.re
@@ -1,40 +1,57 @@
 module Import = {
-  type import = string;
+  type import = {
+    path: Path.t,
+    target: Path.t,
+    import: string,
+  };
   type t =
-    | Local(import, Path.t)
-    | Unresolved(import, Path.t)
+    | Local(import)
+    | Unresolved(import)
     | External(import);
   let v = (import, ~path) => {
     let x = import->String.get(0);
     switch (x) {
     | '.'
     | '/' =>
-      let filePath =
+      let target =
         x === '.' ? path->Path.parent->Path.addSeg(import) : import->Path.v;
-      filePath
+      target
       ->Resolve.resolve
       ->(
           fun
-          | Ok(p) => Local(import, p)
-          | _ => Unresolved(import, filePath)
+          | Ok(resolved) => Local({path, target: resolved, import})
+          | Error(_) => Unresolved({path, target, import})
         );
     // External could also be ../../node_modules/@thing/beep
     // so need to handle that at some point
-    | _ => External(import)
+    | _ => External({path, target: Path.v(import), import})
     };
   };
-  let toString =
+  let path =
     fun
-    | Local(s, _)
-    | Unresolved(s, _)
-    | External(s) => s;
+    | Local(x)
+    | Unresolved(x)
+    | External(x) => x.path;
+  let import =
+    fun
+    | Local(x)
+    | Unresolved(x)
+    | External(x) => x.import;
+  let target =
+    fun
+    | Local(x)
+    | Unresolved(x)
+    | External(x) => x.target;
 };
 
 module Comparator =
   Id.MakeComparable({
     type t = Import.t;
     let cmp = (a, b) =>
-      switch (a->Import.toString, b->Import.toString) {
+      switch (
+        a->Import.target->Path.toString,
+        b->Import.target->Path.toString,
+      ) {
       | (x, y) => Pervasives.compare(x, y)
       };
   });

--- a/src/library/ImportSet.rei
+++ b/src/library/ImportSet.rei
@@ -1,11 +1,17 @@
 module Import: {
-  type import = string;
+  type import = {
+    path: Path.t,
+    target: Path.t,
+    import: string,
+  };
   type t =
-    | Local(import, Path.t)
-    | Unresolved(import, Path.t)
+    | Local(import)
+    | Unresolved(import)
     | External(import);
   let v: (string, ~path: Path.t) => t;
-  let toString: t => string;
+  let path: t => Path.t;
+  let target: t => Path.t;
+  let import: t => string;
 };
 type t;
 let empty: t;

--- a/src/library/ImportSet.rei
+++ b/src/library/ImportSet.rei
@@ -1,11 +1,11 @@
 module Import: {
+  type import = string;
   type t =
-    | Local(Path.t)
-    | Unresolved(Path.t)
-    | External(string);
+    | Local(import, Path.t)
+    | Unresolved(import, Path.t)
+    | External(import);
   let v: (string, ~path: Path.t) => t;
   let toString: t => string;
-  let pp: (t, ~cwd: Path.t) => string;
 };
 type t;
 let empty: t;

--- a/src/library/Pack.re
+++ b/src/library/Pack.re
@@ -38,8 +38,8 @@ let parseImports = paths =>
   paths
   ->List.map(t => {
       switch (t) {
-      | ImportSet.Import.Local(p) =>
-        switch (p->Fs.read) {
+      | ImportSet.Import.Local(t) =>
+        switch (t.target->Fs.read) {
         | Ok(s) =>
           // obviously slow on big files
           // should make custom require/import
@@ -50,7 +50,7 @@ let parseImports = paths =>
             ->List.fromArray
             ->List.map(x => Some(x)->AST.parseRequires)
             ->List.flatten
-            ->List.map(x => x->ImportSet.Import.v(~path=p))
+            ->List.map(x => x->ImportSet.Import.v(~path=t.target))
           | Error(_) => []
           }
         | Error(_) => []


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/167161/82129124-81612900-978e-11ea-9b48-a421989c3f75.png)

I think these errors probably need to be grouped by file so they can be found.
The flow ast gives location in the file too. Ideally this could be an editor plugin so you can see missing imports while developing. 🤷🏻‍♂️